### PR TITLE
Update distance display precision for workouts

### DIFF
--- a/OutRun/Models/Formatting/CustomMeasurementFormatting.swift
+++ b/OutRun/Models/Formatting/CustomMeasurementFormatting.swift
@@ -49,7 +49,14 @@ class CustomMeasurementFormatting {
             timeFormatter.zeroFormattingBehavior = .pad
             return timeFormatter.string(from: seconds) ?? "Error"
         case .distance:
-            return formatter.string(from: measurement.converting(to: UserPreferences.distanceMeasurementType.safeValue))
+            let convertedMeasurement = measurement.converting(to: UserPreferences.distanceMeasurementType.safeValue)
+            // Apply different rounding based on unit: 1 decimal for miles, 0 decimals for kilometers
+            if UserPreferences.distanceMeasurementType.safeValue == UnitLength.miles {
+                formatter.numberFormatter.roundingIncrement = 0.1
+            } else {
+                formatter.numberFormatter.roundingIncrement = 1
+            }
+            return formatter.string(from: convertedMeasurement)
         case .altitude:
             return formatter.string(from: measurement.converting(to: UserPreferences.altitudeMeasurementType.safeValue))
         case .speed:


### PR DESCRIPTION
Modified CustomMeasurementFormatting to apply unit-specific rounding
- Updated distance formatting to show 1 decimal place for miles (e.g., 3.2 mi)
- Updated distance formatting to show no decimals for kilometers (e.g., 5 km)
