### PR TITLE
Close workout window when saving or discarding

### DIFF
--- a/OutRun/Controllers/Workout/NewWorkoutViewController.swift
+++ b/OutRun/Controllers/Workout/NewWorkoutViewController.swift
@@ -69,13 +69,19 @@ class NewWorkoutViewController: MapViewControllerWithConatinerView, WorkoutBuild
                 }
             }
         case .stop:
-            self.builder.finish { (success) in
+            self.builder.finish(completion: { (success) in
                 if success {
                     print("[NewWorkout] finished recording")
                 } else {
                     self.displayBuilderFailureError()
                 }
-            }
+            }, onSaveOrDiscard: { _ in
+                DispatchQueue.main.async {
+                    self.dismiss(animated: true) {
+                        print("[NewWorkout] dismissed after save or discard")
+                    }
+                }
+            })
         case .pauseOrContinue:
             if self.builder.status == .paused {
                 self.builder.startOrResume { (success) in
@@ -314,7 +320,7 @@ class NewWorkoutViewController: MapViewControllerWithConatinerView, WorkoutBuild
                         title: LS("NewWorkoutViewController.Cancel.Error.Recording.Action.StopRecording"),
                         style: .destructive,
                         action: { _ in
-                            self.builder.finish(shouldProvideCompletionActions: false) { (success) in
+                            self.builder.finish(shouldProvideCompletionActions: false, completion: { (success) in
                                 if success {
                                     alert?.dismiss(animated: true) {
                                         self.dismiss(animated: true) {
@@ -325,7 +331,7 @@ class NewWorkoutViewController: MapViewControllerWithConatinerView, WorkoutBuild
                                     self.displayBuilderFailureError()
                                     print("[NewWorkout] stop tracking failed")
                                 }
-                            }
+                            })
                         }
                     ),
                     (

--- a/OutRun/Models/Workout/WorkoutBuilder/WorkoutBuilder.swift
+++ b/OutRun/Models/Workout/WorkoutBuilder/WorkoutBuilder.swift
@@ -120,9 +120,11 @@ class WorkoutBuilder: ApplicationStateObserver {
     
     /**
      Stops and resets the `WorkoutBuilder` if this action is appropriate giving the recorded data to an instance of `WorkoutCompletionActionHandler`
+     - parameter shouldProvideCompletionActions: whether to display completion actions or save automatically
      - parameter completion: a closure with a success boolean as a parameter indicating if the action was performed
+     - parameter onSaveOrDiscard: optional closure called when Save or Discard is selected (not called for Continue)
      */
-    public func finish(shouldProvideCompletionActions: Bool = true, completion: @escaping (Bool) -> Void) {
+    public func finish(shouldProvideCompletionActions: Bool = true, completion: @escaping (Bool) -> Void, onSaveOrDiscard: ((Bool) -> Void)? = nil) {
         
         let completion = makeClosureThreadSafe(completion)
         let timestamp = Date()
@@ -135,7 +137,7 @@ class WorkoutBuilder: ApplicationStateObserver {
                 
                 if let snapshot = self.createSnapshot() {
                     
-                    let handler = WorkoutCompletionActionHandler(snapshot: snapshot, builder: self)
+                    let handler = WorkoutCompletionActionHandler(snapshot: snapshot, builder: self, completionHandler: onSaveOrDiscard)
                     
                     if shouldProvideCompletionActions {
                         handler.display()

--- a/OutRun/Models/Workout/WorkoutCompletionActionHandler.swift
+++ b/OutRun/Models/Workout/WorkoutCompletionActionHandler.swift
@@ -32,14 +32,20 @@ class WorkoutCompletionActionHandler {
     /// If `true` the `WorkoutCompletionActionHandler` did already perform an action, so no additional action should be taken
     private var didPerformAction: Bool = false
     
+    /// Completion handler called when save or discard is selected
+    private var completionHandler: ((Bool) -> Void)?
+    
     /**
      Initialises the `WorkoutCompletionActionHandler` with the needed snapshot of an `TempWorkout`
      - parameter snapshot: a `TempWorkout` object to be saved, discarded or continued
+     - parameter builder: a `WorkoutBuilder` reference to continue the workout if needed
+     - parameter completionHandler: a closure to be called when save or discard is selected
      */
-    public init(snapshot: TempWorkout, builder: WorkoutBuilder) {
+    public init(snapshot: TempWorkout, builder: WorkoutBuilder, completionHandler: ((Bool) -> Void)? = nil) {
         
         self.snapshot = snapshot
         self.builder = builder
+        self.completionHandler = completionHandler
         
     }
     
@@ -70,6 +76,8 @@ class WorkoutCompletionActionHandler {
             let banner = TextBanner(text: LS("NewWorkoutCompletion.Save." + (success ? "Success" : "Error")))
             banner.duration = 5
             banner.show()
+            
+            self.completionHandler?(false)
             
         }
         
@@ -118,6 +126,8 @@ class WorkoutCompletionActionHandler {
         }
         
         self.didPerformAction = true
+        
+        self.completionHandler?(false)
         
     }
     


### PR DESCRIPTION
- Add completion callback to WorkoutCompletionActionHandler that triggers when Save or Discard is selected
- Update WorkoutBuilder.finish() to accept optional onSaveOrDiscard callback
- Dismiss NewWorkoutViewController when user saves or discards workout
- Continue button keeps the workout window open as expected